### PR TITLE
Troubleshoot GenericDao Issue

### DIFF
--- a/src/main/java/persistence/GenericDao.java
+++ b/src/main/java/persistence/GenericDao.java
@@ -165,7 +165,7 @@ public class GenericDao<T> {
     }
 
     private Session getSession() {
-        return persistence.SessionFactoryProvider.getSessionFactory().openSession();
+        return SessionFactoryProvider.getSessionFactory().openSession();
 
     }
 }

--- a/src/test/java/placeholder.txt
+++ b/src/test/java/placeholder.txt
@@ -1,1 +1,0 @@
-Gaze upon the glory of the Great Placeholder!


### PR DESCRIPTION
The getSession method within GenericDao needed to be tweaked to remove
the package name preceding the SessionFactoryProvider name.

Not sure if the package name was included intentionally where I had removed it from
or if it was an error caused by a rouge alt+enter suggestion from someone's Intellij.

I probably won't leave this pull request open too long but still putting it out here. 