### PR TITLE
Update api to support multi param searches

### DIFF
--- a/src/main/java/team/service/CharacterRequests.java
+++ b/src/main/java/team/service/CharacterRequests.java
@@ -27,7 +27,7 @@ public class CharacterRequests {
         Map<String, Object> searchParamMap = new HashMap<>();
         searchParamMap.put(column, value);
 
-        return Response.status(200).entity(foundCharacterJson).build();
+        return Response.status(200).entity(processRequest(searchParamMap)).build();
     }
 
     @GET

--- a/src/main/java/team/service/CharacterRequests.java
+++ b/src/main/java/team/service/CharacterRequests.java
@@ -64,7 +64,8 @@ public class CharacterRequests {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{column}/{value}/{column2}/{value2}")
     public Response multiParamRequest(@PathParam("column") String column, @PathParam("value") String value,
-                                             @PathParam("column2") String secondaryColumn, @PathParam("value2") String secondaryValue) throws JsonProcessingException {
+                                      @PathParam("column2") String secondaryColumn, @PathParam("value2") String secondaryValue)
+            throws JsonProcessingException {
 
         Map<String, Object> searchParamMap = new HashMap<>();
         searchParamMap.put(column, value);

--- a/src/main/java/team/service/CharacterRequests.java
+++ b/src/main/java/team/service/CharacterRequests.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import team.persistence.GenericDao;
 import team.entity.Character;
 
-
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -14,11 +16,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * This class receives GET requests with data passed along in path parameters
+ * and utilizes the specifics of those path parameters to search within the
+ * character database and returns the data found based upon the search parameters.
+ *
+ */
 @Path("/character")
 public class CharacterRequests {
 
     private String foundCharacterJson;
 
+    /**
+     * This method receives path parameters for a column within the database and
+     * a value to search for within that column. This method then calls the
+     * processRequest method passing that data and returns the Response.
+     *
+     * @param column
+     * @param value
+     * @return
+     * @throws JsonProcessingException
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{column}/{value}")
@@ -30,6 +48,18 @@ public class CharacterRequests {
         return Response.status(200).entity(processRequest(searchParamMap)).build();
     }
 
+    /**
+     * This method receives 2 path parameters for columns within the database and
+     * values to search for within those column. This method then calls the
+     * processRequest method passing that data and returns the Response.
+     *
+     * @param column the database column to search within the database
+     * @param value the value to use when searching the specific database column
+     * @param secondaryColumn the second database column to search within the database
+     * @param secondaryValue the second value to use when searching the specific second database column
+     * @return the found result formatted as JSON within a String.
+     * @throws JsonProcessingException
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{column}/{value}/{column2}/{value2}")
@@ -43,6 +73,14 @@ public class CharacterRequests {
         return Response.status(200).entity(processRequest(searchParamMap)).build();
     }
 
+    /**
+     * This method receives a Key Value pair of database columns and corresponding
+     * values to search for within those columns and then returns the data received
+     * from the query.
+     *
+     * @param searchParamMap The key value pair of data to use within the database search.
+     * @return the found result formatted as JSON within a String.
+     */
     public String processRequest(Map searchParamMap) {
 
         GenericDao dao = new GenericDao(Character.class);

--- a/src/main/java/team/service/CharacterRequests.java
+++ b/src/main/java/team/service/CharacterRequests.java
@@ -10,7 +10,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,19 +22,10 @@ public class CharacterRequests {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{column}/{value}")
-    public Response processRequest(@PathParam("column") String column, @PathParam("value") String value) throws JsonProcessingException {
-        GenericDao dao = new GenericDao(Character.class);
+    public Response singleParamRequest(@PathParam("column") String column, @PathParam("value") String value) throws JsonProcessingException {
 
-
-        List<Character> characters = dao.findByPropertyEqual(column, value);
-
-        ObjectMapper mapper = new ObjectMapper();
-
-        try {
-            foundCharacterJson = mapper.writeValueAsString(characters);
-        } catch (IOException ioe) {
-
-        }
+        Map<String, Object> searchParamMap = new HashMap<>();
+        searchParamMap.put(column, value);
 
         return Response.status(200).entity(foundCharacterJson).build();
     }
@@ -43,14 +33,19 @@ public class CharacterRequests {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{column}/{value}/{column2}/{value2}")
-    public Response processMultiParamRequest(@PathParam("column") String column, @PathParam("value") String value,
+    public Response multiParamRequest(@PathParam("column") String column, @PathParam("value") String value,
                                              @PathParam("column2") String secondaryColumn, @PathParam("value2") String secondaryValue) throws JsonProcessingException {
-        GenericDao dao = new GenericDao(Character.class);
 
         Map<String, Object> searchParamMap = new HashMap<>();
         searchParamMap.put(column, value);
         searchParamMap.put(secondaryColumn, secondaryValue);
 
+        return Response.status(200).entity(processRequest(searchParamMap)).build();
+    }
+
+    public String processRequest(Map searchParamMap) {
+
+        GenericDao dao = new GenericDao(Character.class);
         List<Character> characters = dao.findByPropertyEqual(searchParamMap);
 
         ObjectMapper mapper = new ObjectMapper();
@@ -61,6 +56,7 @@ public class CharacterRequests {
 
         }
 
-        return Response.status(200).entity(foundCharacterJson).build();
+        return foundCharacterJson;
+
     }
 }

--- a/src/main/java/team/service/CharacterRequests.java
+++ b/src/main/java/team/service/CharacterRequests.java
@@ -11,7 +11,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Path("/character")
 public class CharacterRequests {
@@ -24,9 +26,32 @@ public class CharacterRequests {
     public Response processRequest(@PathParam("column") String column, @PathParam("value") String value) throws JsonProcessingException {
         GenericDao dao = new GenericDao(Character.class);
 
-//        Character foundCharacter = (Character) dao.findByPropertyEqual("name", characterName);
 
         List<Character> characters = dao.findByPropertyEqual(column, value);
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            foundCharacterJson = mapper.writeValueAsString(characters);
+        } catch (IOException ioe) {
+
+        }
+
+        return Response.status(200).entity(foundCharacterJson).build();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/{column}/{value}/{column2}/{value2}")
+    public Response processMultiParamRequest(@PathParam("column") String column, @PathParam("value") String value,
+                                             @PathParam("column2") String secondaryColumn, @PathParam("value2") String secondaryValue) throws JsonProcessingException {
+        GenericDao dao = new GenericDao(Character.class);
+
+        Map<String, Object> searchParamMap = new HashMap<>();
+        searchParamMap.put(column, value);
+        searchParamMap.put(secondaryColumn, secondaryValue);
+
+        List<Character> characters = dao.findByPropertyEqual(searchParamMap);
 
         ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/resources/sql/dump.sql
+++ b/src/main/resources/sql/dump.sql
@@ -11,6 +11,23 @@ create table characters (
 );
 
 insert into characters (name, media, franchise, species, alignment) values ('Gandalf', 'book', 'Lord of the Rings', 'Maia', 'Good');
+insert into characters (name, media, franchise, species, alignment) values ('Gollum', 'book', 'Lord of the Rings', 'Maia', 'Good');
 insert into characters (name, media, franchise, species, alignment) values ('Ripley', 'movie', 'Alien', 'Human', 'Good');
+insert into characters (name, media, franchise, species, alignment) values ('Bishop', 'movie', 'Alien', 'Android', 'Unknown');
+insert into characters (name, media, franchise, species, alignment) values ('David 8', 'movie', 'Alien', 'Android', 'Evil');
 insert into characters (name, media, franchise, species, alignment) values ('Luke Skywalker', 'movie', 'Star Wars', 'Human', 'Good');
 insert into characters (name, media, franchise, species, alignment) values ('Neo', 'movie', 'The Matrix', 'Human', 'Good');
+insert into characters (name, media, franchise, species, alignment) values ('Tetsuo Shima', 'anime', 'Akira', 'Human', 'Evil');
+insert into characters (name, media, franchise, species, alignment) values ('Kei', 'anime', 'Akira', 'Human', 'Good');
+insert into characters (name, media, franchise, species, alignment) values ('John Wick', 'movie', 'John Wick', 'Human', 'Anti-hero');
+insert into characters (name, media, franchise, species, alignment) values ('Rocket Racoon', 'various', 'Guardians of the Galaxy', 'Raccoon', 'Anti-hero');
+insert into characters (name, media, franchise, species, alignment) values ('Peter Jason Quill', 'various', 'Guardians of the Galaxy', 'Raccoon', 'Good');
+insert into characters (name, media, franchise, species, alignment) values ('Cloud Strife', 'video game', 'Final Fantasy', 'Human', 'Good');
+insert into characters (name, media, franchise, species, alignment) values ('Barret Wallace', 'video game', 'Final Fantasy', 'Human', 'Good');
+insert into characters (name, media, franchise, species, alignment) values ('Rufus Shinra', 'video game', 'Final Fantasy', 'Human', 'Evil');
+insert into characters (name, media, franchise, species, alignment) values ('Sephiroth', 'video game', 'Final Fantasy', 'Human', 'Evil');
+insert into characters (name, media, franchise, species, alignment) values ('Spongebob Squarepants', 'cartoon', 'Spongebob Squarepants', 'Sponge', 'Good');
+insert into characters (name, media, franchise, species, alignment) values ('Scott Pilgrim', 'comic', 'Scott Pilgrim', 'Human', 'Hero');
+insert into characters (name, media, franchise, species, alignment) values ('Ramona Flowers', 'comic', 'Scott Pilgrim', 'Human', 'Hero');
+insert into characters (name, media, franchise, species, alignment) values ('Kim Pine', 'comic', 'Scott Pilgrim', 'Human', 'Hero');
+insert into characters (name, media, franchise, species, alignment) values ('Gideon Graves', 'comic', 'Scott Pilgrim', 'Human', 'Evil');


### PR DESCRIPTION
List of changes:

- Updated CharacterRequests to support both single and two path parameters
- Added javadoc to CharacterRequests
- Added additional data to the sql file so we have more data to demo and test with

Overall the main thing to know about my changes is that you can send one single param as expected. if you send a second param on top of that one, it will act a secondary data filter.  So if I wanted to find characters of a certain "alignment" that are characters from Guardians of the Galaxy, I would first have the path param to filter by franchise and then after that, the alignment I'm looking for. 